### PR TITLE
Add a HUD line for real system time

### DIFF
--- a/src/main/java/com/soradgaming/simplehudenhanced/config/SimpleHudEnhancedConfig.java
+++ b/src/main/java/com/soradgaming/simplehudenhanced/config/SimpleHudEnhancedConfig.java
@@ -128,6 +128,9 @@ public class SimpleHudEnhancedConfig implements ConfigData {
         @ConfigEntry.Gui.CollapsibleObject(startExpanded = false)
         public GameTime gameTime = new GameTime();
         @ConfigEntry.Gui.Tooltip
+        @ConfigEntry.Gui.CollapsibleObject(startExpanded = false)
+        public SystemTime systemTime = new SystemTime();
+        @ConfigEntry.Gui.Tooltip
         public boolean togglePlayerName = false;
         @ConfigEntry.Gui.Tooltip
         public boolean togglePing = false;
@@ -160,5 +163,12 @@ public class SimpleHudEnhancedConfig implements ConfigData {
         public boolean toggleGameTime = true;
         @ConfigEntry.Gui.Tooltip
         public boolean toggleGameTime24Hour = false;
+    }
+
+    public static class SystemTime {
+        @ConfigEntry.Gui.Tooltip
+        public boolean toggleSystemTime = true;
+        @ConfigEntry.Gui.Tooltip
+        public boolean toggleSystemTime24Hour = false;
     }
 }

--- a/src/main/java/com/soradgaming/simplehudenhanced/hud/GameInfo.java
+++ b/src/main/java/com/soradgaming/simplehudenhanced/hud/GameInfo.java
@@ -160,6 +160,24 @@ public class GameInfo {
         return String.format("%d:%02d %s", hour, minute, ampm);
     }
 
+    public String getSystemTime() {
+        if (!config.statusElements.systemTime.toggleSystemTime) {
+            return "";
+        }
+
+        java.time.LocalDateTime time = java.time.LocalDateTime.now();
+
+        // 12-hour format
+        java.time.format.DateTimeFormatter formatter = java.time.format.DateTimeFormatter.ofPattern("h:mm a");
+
+        if (config.statusElements.systemTime.toggleSystemTime24Hour) {
+            // 24-hour format
+            formatter = java.time.format.DateTimeFormatter.ofPattern("H:mm");
+        }
+
+        return(Utilities.translatable("text.hud.simplehudenhanced.systemtime").getString() + ": " + time.format(formatter));
+    }
+
     public String getPlayerName() {
         if (!config.statusElements.togglePlayerName) {
             return "";

--- a/src/main/java/com/soradgaming/simplehudenhanced/hud/HUD.java
+++ b/src/main/java/com/soradgaming/simplehudenhanced/hud/HUD.java
@@ -48,6 +48,7 @@ public class HUD {
         hudInfo.add(GameInformation.getLightLevel());
         hudInfo.add(GameInformation.getBiome());
         hudInfo.add(GameInformation.getTime());
+        hudInfo.add(GameInformation.getSystemTime());
         hudInfo.add(GameInformation.getPlayerName());
         hudInfo.add(GameInformation.getPing());
         hudInfo.add(GameInformation.getServer());

--- a/src/main/resources/assets/simplehudenhanced/lang/en_us.json
+++ b/src/main/resources/assets/simplehudenhanced/lang/en_us.json
@@ -16,6 +16,7 @@
   "text.hud.simplehudenhanced.lightlevel": "Light Level",
   "text.hud.simplehudenhanced.block": "Block",
   "text.hud.simplehudenhanced.time": "Time",
+  "text.hud.simplehudenhanced.systemtime": "System Time",
   "text.hud.simplehudenhanced.player": "Player",
   "text.hud.simplehudenhanced.ping": "ms",
   "text.hud.simplehudenhanced.server": "Server Name",
@@ -136,6 +137,13 @@
   "text.autoconfig.simplehudenhanced.option.statusElements.gameTime.toggleGameTime": "In-Game Time Status",
   "text.autoconfig.simplehudenhanced.option.statusElements.gameTime.toggleGameTime24Hour.@Tooltip": "Converts Time to 24 Hour Format",
   "text.autoconfig.simplehudenhanced.option.statusElements.gameTime.toggleGameTime24Hour": "24 Hour Format",
+  
+  "text.autoconfig.simplehudenhanced.option.statusElements.systemTime.@Tooltip": "Show your current system time in the HUD",
+  "text.autoconfig.simplehudenhanced.option.statusElements.systemTime": "System Time Status",
+  "text.autoconfig.simplehudenhanced.option.statusElements.systemTime.toggleSystemTime.@Tooltip": "Show your current system time in the HUD",
+  "text.autoconfig.simplehudenhanced.option.statusElements.systemTime.toggleSystemTime": "System Time Status",
+  "text.autoconfig.simplehudenhanced.option.statusElements.systemTime.toggleSystemTime24Hour.@Tooltip": "Converts Time to 24 Hour Format",
+  "text.autoconfig.simplehudenhanced.option.statusElements.systemTime.toggleSystemTime24Hour": "24 Hour Format",
   
   "text.autoconfig.simplehudenhanced.option.statusElements.togglePlayerName.@Tooltip": "Show your current player name in the HUD",
   "text.autoconfig.simplehudenhanced.option.statusElements.togglePlayerName": "Player Name",


### PR DESCRIPTION
I often play Minecraft in full-screen mode where I don't have quick access to my real clock. It'd be really helpful if the HUD had a line that showed the real system time in addition to the game time, so I'm sending a pull request here to add it.

I've placed it below the game time line with a prefix "System Time", but please feel free to suggest better text/placements if needed (maybe it's too long for a line?).

Built locally to test for 1.20 and confirmed it works. Screenshots:

![javaw_2023-07-15_01-01-42](https://github.com/SoRadGaming/Simple-HUD-Enhanced/assets/60749079/5f09df28-5ac3-44be-b634-69ff56b0bb36)
![javaw_2023-07-15_01-04-12](https://github.com/SoRadGaming/Simple-HUD-Enhanced/assets/60749079/357899fe-6c80-4024-a475-5a54bcddfac0)